### PR TITLE
Extract reusable fire runtime consumers

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,11 +1,146 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import FluidSimulation from './components/FluidSimulation';
+import {
+  FIRE_RUNTIME_CONSUMER_MAP,
+  FIRE_RUNTIME_CONSUMERS,
+  type FireRuntimeConsumerId,
+} from './components/fireRuntime/consumers';
 import TooltipLayer from './components/TooltipLayer';
 
-const App: React.FC = () => {
+const RuntimeHostOverlay: React.FC<{ consumerId: FireRuntimeConsumerId }> = ({ consumerId }) => {
+  if (consumerId === 'control-deck') return null;
+
+  if (consumerId === 'scene-embed') {
+    return (
+      <div className="runtime-host runtime-host--scene-embed">
+        <div className="runtime-host-toolbar">
+          <span>Scene Graph</span>
+          <span>Lighting</span>
+          <span>Materials</span>
+          <span>FX</span>
+        </div>
+        <div className="runtime-host-caption">
+          Embedded fire actor inside a 3D scene shell.
+        </div>
+      </div>
+    );
+  }
+
+  if (consumerId === 'site-hero') {
+    return (
+      <div className="runtime-host runtime-host--site-hero">
+        <div className="runtime-host-nav">
+          <span>Studio</span>
+          <span>Work</span>
+          <span>Services</span>
+          <span>Contact</span>
+        </div>
+        <div className="runtime-host-copy">
+          <p className="runtime-kicker">Reusable Fire Runtime</p>
+          <h2>Physics-backed fire for interfaces, not just one app.</h2>
+          <p>
+            The same runtime can drive a branded hero, a scene embed, or an ambient backdrop
+            without dragging the full control deck into production surfaces.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (consumerId === 'cursor-fx') {
+    return (
+      <div className="runtime-host runtime-host--cursor-fx">
+        <div className="runtime-cursor-card">Hover target</div>
+        <div className="runtime-cursor-card">Reveal panel</div>
+        <div className="runtime-cursor-card">Pointer accent</div>
+      </div>
+    );
+  }
+
   return (
-    <div className="app-shell">
-      <FluidSimulation />
+    <div className="runtime-host runtime-host--ambient-background">
+      <div className="runtime-ambient-card">
+        Ambient motion surface
+      </div>
+      <div className="runtime-ambient-card is-wide">
+        Runtime-backed background loop for lobbies, installs, and idle states.
+      </div>
+    </div>
+  );
+};
+
+const App: React.FC = () => {
+  const [activeConsumerId, setActiveConsumerId] = useState<FireRuntimeConsumerId>('control-deck');
+  const activeConsumer = useMemo(
+    () => FIRE_RUNTIME_CONSUMER_MAP[activeConsumerId],
+    [activeConsumerId]
+  );
+
+  return (
+    <div className="app-shell runtime-gallery-app">
+      <aside className="runtime-gallery-sidebar">
+        <div className="runtime-gallery-head">
+          <p className="runtime-gallery-eyebrow">Issue #6</p>
+          <h1>Fire Runtime Consumers</h1>
+          <p>
+            First extraction pass: the app remains the flagship consumer, but the runtime is now
+            exercised through multiple host shells that map to the target reuse cases.
+          </p>
+        </div>
+
+        <div className="runtime-gallery-list" role="tablist" aria-label="Runtime consumers">
+          {FIRE_RUNTIME_CONSUMERS.map((consumer) => (
+            <button
+              key={consumer.id}
+              type="button"
+              role="tab"
+              aria-selected={activeConsumerId === consumer.id}
+              className={`runtime-gallery-tab ${activeConsumerId === consumer.id ? 'is-active' : ''}`}
+              onClick={() => setActiveConsumerId(consumer.id)}
+            >
+              <span className="runtime-gallery-tab-label">{consumer.label}</span>
+              <span className="runtime-gallery-tab-tagline">{consumer.tagline}</span>
+            </button>
+          ))}
+        </div>
+
+        <dl className="runtime-gallery-details">
+          <div>
+            <dt>Use Case</dt>
+            <dd>{activeConsumer.useCase}</dd>
+          </div>
+          <div>
+            <dt>Consumer Goal</dt>
+            <dd>{activeConsumer.description}</dd>
+          </div>
+          <div>
+            <dt>Runtime Mode</dt>
+            <dd>
+              {activeConsumer.initialQualityMode} / {activeConsumer.initialCompositionMode}
+            </dd>
+          </div>
+        </dl>
+      </aside>
+
+      <main className="runtime-gallery-stage">
+        <div className="runtime-gallery-stage-head">
+          <div>
+            <p className="runtime-gallery-eyebrow">Active Consumer</p>
+            <h2>{activeConsumer.label}</h2>
+          </div>
+          <p>{activeConsumer.tagline}</p>
+        </div>
+
+        <div className={`runtime-gallery-frame runtime-gallery-frame--${activeConsumer.id}`}>
+          <FluidSimulation
+            key={activeConsumer.id}
+            consumerId={activeConsumer.id}
+            className="runtime-gallery-sim"
+          />
+          <RuntimeHostOverlay consumerId={activeConsumer.id} />
+        </div>
+      </main>
+
       <TooltipLayer />
     </div>
   );

--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ Detailed limits and edge-case notes are documented in [STABILITY.md](STABILITY.m
 ```
 firesim/
 ├── components/
-│   ├── FluidSimulation.tsx   # Main control deck, world scene, presets, and fire runtime wiring
+│   ├── FluidSimulation.tsx   # Main runtime host that can mount as different consumers
+│   ├── fireRuntime/
+│   │   ├── consumers.ts      # Consumer definitions for control deck, 3D scene, hero, cursor, ambient
+│   │   └── transport.ts      # Reusable GPU transport/buffer contract extracted from the app shell
 │   ├── fluid/
 │   │   ├── assetSystem.ts    # Scanned/procedural log asset loading
 │   │   ├── debugConfig.ts    # Quality, composition, and debug mode mappings
@@ -85,10 +88,22 @@ firesim/
 │   └── TooltipLayer.tsx      # Global tooltip surface for deck controls
 ├── tests/stability/         # Playwright fuzz + snapshot stability harness
 ├── webgpu.d.ts              # Local WebGPU DOM typing surface for this project
-├── App.tsx                  # Main application component
+├── App.tsx                  # Consumer gallery that remounts the runtime in multiple host shells
 ├── types.ts                 # TypeScript type definitions
 └── index.css                # Deck styling
 ```
+
+## 🔌 Runtime Consumers
+
+The app now includes a consumer gallery that exercises the same fire runtime in five host shapes:
+
+- `Control Deck` - the full authoring/debug product
+- `3D Scene Embed` - a minimal scene-mounted runtime surface
+- `2D Site Hero` - a branded hero/background presentation
+- `Cursor Effect` - a lighter fire-only interactive effect shell
+- `Ambient Background` - a low-UI background/idle consumer
+
+This is the first extraction pass toward making FireSim behave more like a reusable runtime than a single hardcoded app shell.
 
 ## 🎯 How It Works
 

--- a/components/FluidSimulation.tsx
+++ b/components/FluidSimulation.tsx
@@ -27,6 +27,11 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three/webgpu';
 import { RectAreaLightTexturesLib } from 'three/examples/jsm/lights/RectAreaLightTexturesLib.js';
 import {
+    FIRE_RUNTIME_CONSUMER_MAP,
+    type FireRuntimeConsumerId,
+} from './fireRuntime/consumers';
+import { FluidTransport } from './fireRuntime/transport';
+import {
     addCampfireLogPile,
     WOOD_ASSET_STATE_LABELS,
     type WoodAssetState,
@@ -52,421 +57,6 @@ import {
     WOOD_PILE_DESCRIPTOR,
     type WoodCombustionLogState,
 } from './fluid/woodSystem';
-
-/**
- * SECTION 1: TRANSPORT LAYER (3D)
- */
-
-class ShaderContract {
-  public layout: GPUPipelineLayout;
-  public bindGroupLayout: GPUBindGroupLayout;
-
-  constructor(device: GPUDevice, label: string, entries: any[]) {
-    this.bindGroupLayout = device.createBindGroupLayout({
-      entries,
-      label: `${label}_BGL`
-    });
-
-    this.layout = device.createPipelineLayout({
-      bindGroupLayouts: [this.bindGroupLayout],
-      label: `${label}_PL`
-    });
-  }
-
-  createBindGroup(device: GPUDevice, label: string, entries: any[]): GPUBindGroup {
-    return device.createBindGroup({
-      layout: this.bindGroupLayout,
-      entries,
-      label: `${label}_BG`
-    });
-  }
-}
-
-class FluidTransport {
-  public uniformBuffer: GPUBuffer;
-
-  private uniformStaging: ArrayBuffer;
-  private uniformView: DataView;
-
-  public densityA: GPUBuffer;
-  public densityB: GPUBuffer;
-  public fuelA: GPUBuffer;
-  public fuelB: GPUBuffer;
-  public sootA: GPUBuffer;
-  public sootB: GPUBuffer;
-  public velocityA: GPUBuffer;
-  public velocityB: GPUBuffer;
-  public velocityScratch: GPUBuffer;
-  public divergence: GPUBuffer;
-  public pressureA: GPUBuffer;
-  public pressureB: GPUBuffer;
-  public occupancy: GPUBuffer;
-  public rayStepCounter: GPUBuffer;
-  public velocityBufferSize: number;
-  public macrocellsPerAxis: number;
-
-  public physicsContract!: ShaderContract;
-  public renderContract!: ShaderContract;
-  public projectionDivContract!: ShaderContract;
-  public projectionJacobiContract!: ShaderContract;
-  public projectionGradContract!: ShaderContract;
-  public occupancyContract!: ShaderContract;
-
-  public physicsGroups: GPUBindGroup[] = [];
-  public renderGroups: GPUBindGroup[] = [];
-  public projectionDivGroups: GPUBindGroup[] = [];
-  public projectionJacobiGroups: GPUBindGroup[] = [];
-  public projectionGradGroups: GPUBindGroup[][] = [[], []];
-  public occupancyGroups: GPUBindGroup[] = [];
-
-  constructor(
-    private device: GPUDevice,
-    public dim: number
-  ) {
-    const VOXEL_COUNT = dim * dim * dim;
-
-    this.uniformBuffer = device.createBuffer({
-      size: 288,
-      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
-    });
-
-    this.uniformStaging = new ArrayBuffer(288);
-    this.uniformView = new DataView(this.uniformStaging);
-
-    const bufferUsage = (window as any).GPUBufferUsage;
-    const storageUsage = bufferUsage.STORAGE | bufferUsage.COPY_DST | bufferUsage.COPY_SRC;
-
-    this.densityA = device.createBuffer({ size: VOXEL_COUNT * 4, usage: storageUsage });
-    this.densityB = device.createBuffer({ size: VOXEL_COUNT * 4, usage: storageUsage });
-
-    this.fuelA = device.createBuffer({ size: VOXEL_COUNT * 4, usage: storageUsage });
-    this.fuelB = device.createBuffer({ size: VOXEL_COUNT * 4, usage: storageUsage });
-
-    this.sootA = device.createBuffer({ size: VOXEL_COUNT * 4, usage: storageUsage });
-    this.sootB = device.createBuffer({ size: VOXEL_COUNT * 4, usage: storageUsage });
-
-    this.velocityBufferSize = VOXEL_COUNT * 16;
-    this.velocityA = device.createBuffer({ size: this.velocityBufferSize, usage: storageUsage });
-    this.velocityB = device.createBuffer({ size: this.velocityBufferSize, usage: storageUsage });
-    this.velocityScratch = device.createBuffer({ size: this.velocityBufferSize, usage: storageUsage });
-    this.divergence = device.createBuffer({ size: VOXEL_COUNT * 4, usage: storageUsage });
-    this.pressureA = device.createBuffer({ size: VOXEL_COUNT * 4, usage: storageUsage });
-    this.pressureB = device.createBuffer({ size: VOXEL_COUNT * 4, usage: storageUsage });
-
-    // Task C: Macrocell occupancy grid (8 voxels per macrocell per axis)
-    const MACROCELL_SIZE = 8;
-    this.macrocellsPerAxis = Math.ceil(dim / MACROCELL_SIZE);
-    const macrocellCount = this.macrocellsPerAxis ** 3;
-    this.occupancy = device.createBuffer({ size: macrocellCount * 4, usage: storageUsage });
-    device.queue.writeBuffer(this.occupancy, 0, new Uint32Array(macrocellCount));
-
-    // Task B: Ray step counter (single atomic u32)
-    this.rayStepCounter = device.createBuffer({ size: 4, usage: storageUsage });
-
-    const zeroF32 = new Float32Array(VOXEL_COUNT);
-    // Initialize velocity.w = oxygen = 1.0 (fully oxygenated atmosphere)
-    const initVec4 = new Float32Array(VOXEL_COUNT * 4);
-    for (let i = 0; i < VOXEL_COUNT; i++) {
-      initVec4[i * 4 + 3] = 1.0; // .w = oxygen
-    }
-
-    device.queue.writeBuffer(this.densityA, 0, zeroF32);
-    device.queue.writeBuffer(this.densityB, 0, zeroF32);
-    device.queue.writeBuffer(this.fuelA, 0, zeroF32);
-    device.queue.writeBuffer(this.fuelB, 0, zeroF32);
-    device.queue.writeBuffer(this.sootA, 0, zeroF32);
-    device.queue.writeBuffer(this.sootB, 0, zeroF32);
-    device.queue.writeBuffer(this.velocityA, 0, initVec4);
-    device.queue.writeBuffer(this.velocityB, 0, initVec4);
-    device.queue.writeBuffer(this.velocityScratch, 0, initVec4);
-    device.queue.writeBuffer(this.divergence, 0, zeroF32);
-    device.queue.writeBuffer(this.pressureA, 0, zeroF32);
-    device.queue.writeBuffer(this.pressureB, 0, zeroF32);
-    this.initContracts();
-    this.initBindGroups();
-  }
-
-  private initContracts() {
-    this.physicsContract = new ShaderContract(this.device, 'Physics', [
-      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
-      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
-      { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-      { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
-      { binding: 4, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-      { binding: 5, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
-      { binding: 6, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-      { binding: 7, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
-      { binding: 8, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-    ]);
-
-    this.renderContract = new ShaderContract(this.device, 'Render', [
-      { binding: 0, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, buffer: { type: 'uniform' } },
-      { binding: 1, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'read-only-storage' } },
-      { binding: 2, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'read-only-storage' } },
-      { binding: 3, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'read-only-storage' } },
-      { binding: 4, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'read-only-storage' } },
-      { binding: 5, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'read-only-storage' } },
-      { binding: 6, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'storage' } },
-    ]);
-
-    // Task C: Occupancy compute contract
-    this.occupancyContract = new ShaderContract(this.device, 'Occupancy', [
-      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
-      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
-      { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
-      { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
-      { binding: 4, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-    ]);
-
-    this.projectionDivContract = new ShaderContract(this.device, 'ProjectionDiv', [
-      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
-      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
-      { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-    ]);
-
-    this.projectionJacobiContract = new ShaderContract(this.device, 'ProjectionJacobi', [
-      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
-      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
-      { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
-      { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-    ]);
-
-    this.projectionGradContract = new ShaderContract(this.device, 'ProjectionGrad', [
-      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
-      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
-      { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
-      { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-    ]);
-  }
-
-  private initBindGroups() {
-    this.physicsGroups[0] = this.physicsContract.createBindGroup(this.device, 'Phys0', [
-      { binding: 0, resource: { buffer: this.uniformBuffer } },
-      { binding: 1, resource: { buffer: this.densityA } },
-      { binding: 2, resource: { buffer: this.densityB } },
-      { binding: 3, resource: { buffer: this.velocityA } },
-      { binding: 4, resource: { buffer: this.velocityB } },
-      { binding: 5, resource: { buffer: this.fuelA } },
-      { binding: 6, resource: { buffer: this.fuelB } },
-      { binding: 7, resource: { buffer: this.sootA } },
-      { binding: 8, resource: { buffer: this.sootB } },
-    ]);
-
-    this.renderGroups[0] = this.renderContract.createBindGroup(this.device, 'Render0', [
-      { binding: 0, resource: { buffer: this.uniformBuffer } },
-      { binding: 1, resource: { buffer: this.densityB } },
-      { binding: 2, resource: { buffer: this.velocityB } },
-      { binding: 3, resource: { buffer: this.fuelB } },
-      { binding: 4, resource: { buffer: this.sootB } },
-      { binding: 5, resource: { buffer: this.occupancy } },
-      { binding: 6, resource: { buffer: this.rayStepCounter } },
-    ]);
-
-    this.physicsGroups[1] = this.physicsContract.createBindGroup(this.device, 'Phys1', [
-      { binding: 0, resource: { buffer: this.uniformBuffer } },
-      { binding: 1, resource: { buffer: this.densityB } },
-      { binding: 2, resource: { buffer: this.densityA } },
-      { binding: 3, resource: { buffer: this.velocityB } },
-      { binding: 4, resource: { buffer: this.velocityA } },
-      { binding: 5, resource: { buffer: this.fuelB } },
-      { binding: 6, resource: { buffer: this.fuelA } },
-      { binding: 7, resource: { buffer: this.sootB } },
-      { binding: 8, resource: { buffer: this.sootA } },
-    ]);
-
-    this.renderGroups[1] = this.renderContract.createBindGroup(this.device, 'Render1', [
-      { binding: 0, resource: { buffer: this.uniformBuffer } },
-      { binding: 1, resource: { buffer: this.densityA } },
-      { binding: 2, resource: { buffer: this.velocityA } },
-      { binding: 3, resource: { buffer: this.fuelA } },
-      { binding: 4, resource: { buffer: this.sootA } },
-      { binding: 5, resource: { buffer: this.occupancy } },
-      { binding: 6, resource: { buffer: this.rayStepCounter } },
-    ]);
-
-    // Task C: Occupancy bind groups (match render group buffer selection)
-    this.occupancyGroups[0] = this.occupancyContract.createBindGroup(this.device, 'Occupancy0', [
-      { binding: 0, resource: { buffer: this.uniformBuffer } },
-      { binding: 1, resource: { buffer: this.densityB } },
-      { binding: 2, resource: { buffer: this.fuelB } },
-      { binding: 3, resource: { buffer: this.sootB } },
-      { binding: 4, resource: { buffer: this.occupancy } },
-    ]);
-    this.occupancyGroups[1] = this.occupancyContract.createBindGroup(this.device, 'Occupancy1', [
-      { binding: 0, resource: { buffer: this.uniformBuffer } },
-      { binding: 1, resource: { buffer: this.densityA } },
-      { binding: 2, resource: { buffer: this.fuelA } },
-      { binding: 3, resource: { buffer: this.sootA } },
-      { binding: 4, resource: { buffer: this.occupancy } },
-    ]);
-
-    this.projectionDivGroups[0] = this.projectionDivContract.createBindGroup(this.device, 'ProjectionDiv0', [
-      { binding: 0, resource: { buffer: this.uniformBuffer } },
-      { binding: 1, resource: { buffer: this.velocityB } },
-      { binding: 2, resource: { buffer: this.divergence } },
-    ]);
-
-    this.projectionDivGroups[1] = this.projectionDivContract.createBindGroup(this.device, 'ProjectionDiv1', [
-      { binding: 0, resource: { buffer: this.uniformBuffer } },
-      { binding: 1, resource: { buffer: this.velocityA } },
-      { binding: 2, resource: { buffer: this.divergence } },
-    ]);
-
-    this.projectionJacobiGroups[0] = this.projectionJacobiContract.createBindGroup(this.device, 'ProjectionJacobiA2B', [
-      { binding: 0, resource: { buffer: this.uniformBuffer } },
-      { binding: 1, resource: { buffer: this.divergence } },
-      { binding: 2, resource: { buffer: this.pressureA } },
-      { binding: 3, resource: { buffer: this.pressureB } },
-    ]);
-
-    this.projectionJacobiGroups[1] = this.projectionJacobiContract.createBindGroup(this.device, 'ProjectionJacobiB2A', [
-      { binding: 0, resource: { buffer: this.uniformBuffer } },
-      { binding: 1, resource: { buffer: this.divergence } },
-      { binding: 2, resource: { buffer: this.pressureB } },
-      { binding: 3, resource: { buffer: this.pressureA } },
-    ]);
-
-    this.projectionGradGroups[0][0] = this.projectionGradContract.createBindGroup(this.device, 'ProjectionGrad0PressureA', [
-      { binding: 0, resource: { buffer: this.uniformBuffer } },
-      { binding: 1, resource: { buffer: this.velocityScratch } },
-      { binding: 2, resource: { buffer: this.pressureA } },
-      { binding: 3, resource: { buffer: this.velocityB } },
-    ]);
-
-    this.projectionGradGroups[0][1] = this.projectionGradContract.createBindGroup(this.device, 'ProjectionGrad0PressureB', [
-      { binding: 0, resource: { buffer: this.uniformBuffer } },
-      { binding: 1, resource: { buffer: this.velocityScratch } },
-      { binding: 2, resource: { buffer: this.pressureB } },
-      { binding: 3, resource: { buffer: this.velocityB } },
-    ]);
-
-    this.projectionGradGroups[1][0] = this.projectionGradContract.createBindGroup(this.device, 'ProjectionGrad1PressureA', [
-      { binding: 0, resource: { buffer: this.uniformBuffer } },
-      { binding: 1, resource: { buffer: this.velocityScratch } },
-      { binding: 2, resource: { buffer: this.pressureA } },
-      { binding: 3, resource: { buffer: this.velocityA } },
-    ]);
-
-    this.projectionGradGroups[1][1] = this.projectionGradContract.createBindGroup(this.device, 'ProjectionGrad1PressureB', [
-      { binding: 0, resource: { buffer: this.uniformBuffer } },
-      { binding: 1, resource: { buffer: this.velocityScratch } },
-      { binding: 2, resource: { buffer: this.pressureB } },
-      { binding: 3, resource: { buffer: this.velocityA } },
-    ]);
-  }
-
-  public updateUniforms(
-    now: number,
-    params: any,
-    camera: { pos: number[], target: number[] },
-    sceneType: number
-  ) {
-    const view = this.uniformView;
-
-    view.setFloat32(0, this.dim, true);
-    view.setFloat32(4, now / 1000.0, true);
-    view.setFloat32(8, params.timeStep, true);
-    view.setFloat32(12, params.vorticity, true);
-
-    view.setFloat32(16, params.dissipation, true);
-    view.setFloat32(20, params.buoyancy, true);
-    view.setFloat32(24, params.drag, true);
-    view.setFloat32(28, params.emission, true);
-
-    view.setFloat32(32, params.exposure, true);
-    view.setFloat32(36, params.gamma, true);
-    view.setFloat32(40, sceneType, true);
-    view.setFloat32(44, params.scattering, true);
-
-    view.setFloat32(48, params.absorption, true);
-    view.setFloat32(52, params.smokeWeight, true);
-    view.setFloat32(56, params.plumeTurbulence, true);
-    view.setFloat32(60, params.smokeDissipation, true);
-
-    view.setFloat32(64, camera.pos[0], true);
-    view.setFloat32(68, camera.pos[1], true);
-    view.setFloat32(72, camera.pos[2], true);
-    view.setFloat32(76, 0, true); // cameraPos.w
-
-    view.setFloat32(80, camera.target[0], true);
-    view.setFloat32(84, camera.target[1], true);
-    view.setFloat32(88, camera.target[2], true);
-    view.setFloat32(92, 0, true); // targetPos.w
-
-    view.setFloat32(96, params.windX || 0, true);
-    view.setFloat32(100, params.windZ || 0, true);
-    view.setFloat32(104, params.turbFreq || 28.0, true);
-    view.setFloat32(108, params.turbSpeed || 1.0, true);
-    view.setFloat32(112, params.fuelEfficiency || 1.0, true);
-    view.setFloat32(116, params.heatDiffusion || 0.0, true);
-    view.setFloat32(120, params.stepQuality || 1.0, true);
-    view.setFloat32(124, 0.0, true); // pad4
-
-    // Extended combustion + smoke taxonomy + rendering controls.
-    const fuelEff = params.fuelEfficiency || 1.0;
-    const heightFactor = clamp(params.buoyancy / 8.0, 0.5, 5.0);
-    const baseBurnRate = params.burnRate ?? fuelEff * 6.0;
-    const baseFuelInject = params.fuelInject ?? (0.4 + fuelEff * 0.6);
-    const derivedBurnRate = baseBurnRate / heightFactor;
-    const derivedFuelInject = baseFuelInject * heightFactor;
-    const derivedVolumeHeight = params.volumeHeight ?? 1.0;
-    view.setFloat32(128, params.T_ignite ?? 0.18, true);
-    view.setFloat32(132, params.T_burn ?? 0.55, true);
-    view.setFloat32(136, derivedBurnRate, true);
-    view.setFloat32(140, derivedFuelInject, true);
-
-    view.setFloat32(144, params.heatYield ?? 3.4, true);
-    view.setFloat32(148, params.sootYieldFlame ?? 0.55, true);
-    view.setFloat32(152, params.sootYieldSmolder ?? 1.1, true);
-    view.setFloat32(156, params.hazeConvertRate ?? 0.0, true);
-
-    view.setFloat32(160, params.T_hazeStart ?? 0.35, true);
-    view.setFloat32(164, params.T_hazeFull ?? 0.75, true);
-    view.setFloat32(168, params.anisotropyG ?? 0.82, true);
-    view.setFloat32(172, params.smokeThickness ?? 1.0, true);
-
-    view.setFloat32(176, params.smokeDarkness ?? 0.65, true);
-    view.setFloat32(180, params.flameSharpness ?? 4.0, true);
-    view.setFloat32(184, params.sootDissipation ?? params.smokeDissipation ?? 0.985, true);
-    view.setFloat32(188, derivedVolumeHeight, true);
-
-    // Floor + scene lighting controls.
-    view.setFloat32(192, params.floorUvScale ?? 1.35, true);
-    view.setFloat32(196, params.floorUvWarp ?? 1.2, true);
-    view.setFloat32(200, params.floorBlendStrength ?? 0.85, true);
-    view.setFloat32(204, params.floorNormalStrength ?? 1.05, true);
-
-    view.setFloat32(208, params.floorMicroStrength ?? 0.55, true);
-    view.setFloat32(212, params.floorSootDarkening ?? 1.25, true);
-    view.setFloat32(216, params.floorSootRoughness ?? 1.1, true);
-    view.setFloat32(220, params.floorCharStrength ?? 1.2, true);
-
-    view.setFloat32(224, params.floorContactShadow ?? 1.0, true);
-    view.setFloat32(228, params.floorSpecular ?? 1.1, true);
-    view.setFloat32(232, params.floorFireBounce ?? 1.7, true);
-    view.setFloat32(236, params.floorAmbient ?? 0.55, true);
-
-    view.setFloat32(240, params.lightingFireIntensity ?? 1.75, true);
-    view.setFloat32(244, params.lightingFireFalloff ?? 1.1, true);
-    view.setFloat32(248, params.lightingFlicker ?? 0.2, true);
-    view.setFloat32(252, params.lightingGlow ?? 1.35, true);
-
-    const viewportWidth = Math.max(1, Number(params.renderWidth ?? window.innerWidth));
-    const viewportHeight = Math.max(1, Number(params.renderHeight ?? window.innerHeight));
-    const cameraAspect = viewportWidth / viewportHeight;
-    const cameraTanHalfFov = Math.tan((90.0 * Math.PI / 180.0) * 0.5);
-    view.setFloat32(256, viewportWidth, true);
-    view.setFloat32(260, viewportHeight, true);
-    view.setFloat32(264, cameraAspect, true);
-    view.setFloat32(268, cameraTanHalfFov, true);
-    view.setFloat32(272, params.debugOverlayMode ?? 0.0, true);
-    view.setFloat32(276, params.occlusionMode ?? 1.0, true);
-    view.setFloat32(280, params.rayStepBudget ?? 160.0, true);
-    view.setFloat32(284, params.occlusionStepBudget ?? 80.0, true);
-
-    this.device.queue.writeBuffer(this.uniformBuffer, 0, this.uniformStaging);
-  }
-}
 
 /**
  * SECTION 2: THE WGSL SHADERS
@@ -3029,18 +2619,30 @@ type FireSimHarnessConfig = {
   maxFrames: number | null;
 };
 
-const FluidSimulation: React.FC = () => {
+type FluidSimulationProps = {
+  consumerId?: FireRuntimeConsumerId;
+  className?: string;
+};
+
+const FluidSimulation: React.FC<FluidSimulationProps> = ({
+  consumerId = 'control-deck',
+  className,
+}) => {
+  const consumer = FIRE_RUNTIME_CONSUMER_MAP[consumerId];
+  const initialSceneParams = SCENES.find((scene) => scene.id === consumer.initialSceneId)?.params ?? SCENES[0].params;
+  const initialSimParams = { ...INITIAL_PARAMS, ...initialSceneParams };
+  const rootRef = useRef<HTMLDivElement>(null);
   const worldCanvasRef = useRef<HTMLCanvasElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const worldRuntimeRef = useRef<WorldRuntime | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string | null>(null);
-  const [controlsVisible, setControlsVisible] = useState(true);
+  const [controlsVisible, setControlsVisible] = useState(consumer.showControlsPanel);
   const [isPlaying, setIsPlaying] = useState(true);
-  const [isSmokeEnabled, setIsSmokeEnabled] = useState(true);
-  const [qualityMode, setQualityMode] = useState<QualityMode>('accurate');
+  const [isSmokeEnabled, setIsSmokeEnabled] = useState(consumer.initialSmokeEnabled);
+  const [qualityMode, setQualityMode] = useState<QualityMode>(consumer.initialQualityMode);
   const [diagnosticsTab, setDiagnosticsTab] = useState<DiagnosticsTab>('runtime');
-  const [compositionMode, setCompositionMode] = useState<CompositionDebugMode>('composited');
+  const [compositionMode, setCompositionMode] = useState<CompositionDebugMode>(consumer.initialCompositionMode);
   const [fireOcclusionMode, setFireOcclusionMode] = useState<FireOcclusionMode>('analytic_sdf');
   const [fireOverlayMode, setFireOverlayMode] = useState<FireOverlayMode>('final');
   const [runtimeWarning, setRuntimeWarning] = useState<string | null>(null);
@@ -3068,11 +2670,11 @@ const FluidSimulation: React.FC = () => {
     fieldDivL1: null,
     fieldReactionFraction: null,
   });
-  const [selectedSceneId, setSelectedSceneId] = useState(0);
+  const [selectedSceneId, setSelectedSceneId] = useState(consumer.initialSceneId);
   const [activeSlot, setActiveSlot] = useState<PresetSlot>('A');
   const [presetSlots, setPresetSlots] = useState<Record<PresetSlot, SimParamState>>({
-    A: { ...INITIAL_PARAMS },
-    B: { ...INITIAL_PARAMS },
+    A: { ...initialSimParams },
+    B: { ...initialSimParams },
   });
   const [activeSection, setActiveSection] = useState<ControlSection>('macros');
   const [paramSearch, setParamSearch] = useState('');
@@ -3084,7 +2686,15 @@ const FluidSimulation: React.FC = () => {
     optics: false,
   });
   const readPixelRatio = () => Math.max(1, Math.min(window.devicePixelRatio || 1, 2));
-  const [dimensions, setDimensions] = useState({ width: window.innerWidth, height: window.innerHeight, pixelRatio: readPixelRatio() });
+  const readContainerDimensions = useCallback(() => {
+    const host = rootRef.current;
+    return {
+      width: Math.max(1, Math.round(host?.clientWidth ?? window.innerWidth)),
+      height: Math.max(1, Math.round(host?.clientHeight ?? window.innerHeight)),
+      pixelRatio: readPixelRatio(),
+    };
+  }, []);
+  const [dimensions, setDimensions] = useState(readContainerDimensions);
 
   const readInitialGridSize = () => {
     try {
@@ -3101,8 +2711,8 @@ const FluidSimulation: React.FC = () => {
   };
 
   const [gridSize, setGridSize] = useState(readInitialGridSize);
-  const [runtimeResolutionScale, setRuntimeResolutionScale] = useState(0.9);
-  const [simParams, setSimParams] = useState<SimParamState>({ ...INITIAL_PARAMS });
+  const [runtimeResolutionScale, setRuntimeResolutionScale] = useState(consumer.initialResolutionScale);
+  const [simParams, setSimParams] = useState<SimParamState>({ ...initialSimParams });
   const [lockedParams, setLockedParams] = useState<Record<EditableParamKey, boolean>>(() => (
     Object.fromEntries(PARAM_SPECS.map((spec) => [spec.key, false])) as Record<EditableParamKey, boolean>
   ));
@@ -3111,8 +2721,8 @@ const FluidSimulation: React.FC = () => {
   const deriveTurbulenceCharacterT = (params: Pick<SimParamState, 'plumeTurbulence'>) => clamp(inverseLerp(0.1, 14, params.plumeTurbulence), 0, 1);
 
   const [tuningMacroKnobs, setTuningMacroKnobs] = useState(() => ({
-    smokeAmount: deriveSmokeAmountT(INITIAL_PARAMS),
-    turbulenceCharacter: deriveTurbulenceCharacterT(INITIAL_PARAMS),
+    smokeAmount: deriveSmokeAmountT(initialSimParams),
+    turbulenceCharacter: deriveTurbulenceCharacterT(initialSimParams),
   }));
   const renderScale = useMemo(
     () => clamp(getRenderScale(dimensions.width, dimensions.height, dimensions.pixelRatio) * runtimeResolutionScale, 0.35, 1.0),
@@ -3173,6 +2783,34 @@ const FluidSimulation: React.FC = () => {
     worldNeedsRenderRef.current = true;
   }, []);
 
+  useEffect(() => {
+    const host = rootRef.current;
+    if (!host) return;
+
+    const updateDimensions = () => {
+      setDimensions((prev) => {
+        const next = readContainerDimensions();
+        if (
+          prev.width === next.width &&
+          prev.height === next.height &&
+          prev.pixelRatio === next.pixelRatio
+        ) {
+          return prev;
+        }
+        return next;
+      });
+    };
+
+    updateDimensions();
+    const resizeObserver = new ResizeObserver(updateDimensions);
+    resizeObserver.observe(host);
+    window.addEventListener('resize', updateDimensions);
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', updateDimensions);
+    };
+  }, [readContainerDimensions]);
+
   useEffect(() => { paramsRef.current = simParams; }, [simParams]);
   useEffect(() => { playingRef.current = isPlaying; }, [isPlaying]);
   useEffect(() => { sceneRef.current = selectedSceneId; }, [selectedSceneId]);
@@ -3185,10 +2823,12 @@ const FluidSimulation: React.FC = () => {
     const runtime = worldRuntimeRef.current;
     if (!runtime) return;
     const targetPixelRatio = Math.min(window.devicePixelRatio || 1, qualityMode === 'accurate' ? 0.95 : 0.85);
+    runtime.camera.aspect = dimensions.width / Math.max(1, dimensions.height);
+    runtime.camera.updateProjectionMatrix();
     runtime.renderer.setPixelRatio(targetPixelRatio);
-    runtime.renderer.setSize(window.innerWidth, window.innerHeight, false);
+    runtime.renderer.setSize(dimensions.width, dimensions.height, false);
     markWorldDirty();
-  }, [markWorldDirty, qualityMode]);
+  }, [dimensions.height, dimensions.width, markWorldDirty, qualityMode]);
   useEffect(() => { markWorldDirty(); }, [markWorldDirty, simParams, compositionMode, dimensions.width, dimensions.height, dimensions.pixelRatio]);
 
   useEffect(() => {
@@ -3274,11 +2914,6 @@ const FluidSimulation: React.FC = () => {
   const copyRuntimeLogToClipboard = useCallback(() => {
     void copyText(getRuntimeLogText(), 'Copied runtime log');
   }, [copyText, getRuntimeLogText]);
-
-  useEffect(() => {
-    const handleResize = () => setDimensions({ width: window.innerWidth, height: window.innerHeight, pixelRatio: readPixelRatio() });
-    window.addEventListener('resize', handleResize); return () => window.removeEventListener('resize', handleResize);
-  }, []);
 
   const handleSceneChange = useCallback((id: number) => {
     setSelectedSceneId(id);
@@ -3630,7 +3265,6 @@ const FluidSimulation: React.FC = () => {
     if (!canvas || !navigator.gpu) return;
 
     let destroyed = false;
-    let removeResize = () => {};
 
     const initWorld = async () => {
       const getWorldPixelRatio = () => Math.min(window.devicePixelRatio || 1, qualityModeRef.current === 'accurate' ? 0.9 : 0.8);
@@ -3646,7 +3280,7 @@ const FluidSimulation: React.FC = () => {
       }
 
       renderer.setPixelRatio(getWorldPixelRatio());
-      renderer.setSize(window.innerWidth, window.innerHeight, false);
+      renderer.setSize(dimensions.width, dimensions.height, false);
       renderer.outputColorSpace = THREE.SRGBColorSpace;
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = 1.0;
@@ -3671,7 +3305,7 @@ const FluidSimulation: React.FC = () => {
 
       const camera = new THREE.PerspectiveCamera(
         90,
-        window.innerWidth / Math.max(1, window.innerHeight),
+        dimensions.width / Math.max(1, dimensions.height),
         0.02,
         120
       );
@@ -3835,19 +3469,6 @@ const FluidSimulation: React.FC = () => {
         logLastUpdateMs: performance.now(),
         lastWorldRenderMs: 0,
       };
-
-      const handleResize = () => {
-        const runtime = worldRuntimeRef.current;
-        if (!runtime) return;
-        const aspect = window.innerWidth / Math.max(1, window.innerHeight);
-        runtime.camera.aspect = aspect;
-        runtime.camera.updateProjectionMatrix();
-        runtime.renderer.setPixelRatio(getWorldPixelRatio());
-        runtime.renderer.setSize(window.innerWidth, window.innerHeight, false);
-        worldNeedsRenderRef.current = true;
-      };
-      window.addEventListener('resize', handleResize);
-      removeResize = () => window.removeEventListener('resize', handleResize);
 
       const renderWorldNow = () => {
         const runtime = worldRuntimeRef.current;
@@ -4023,7 +3644,6 @@ const FluidSimulation: React.FC = () => {
 
     return () => {
       destroyed = true;
-      removeResize();
       renderWorldRef.current = null;
 
       const runtime = worldRuntimeRef.current;
@@ -4914,10 +4534,23 @@ f32(284, occlusionStepBudget);
     windGusts
   ]);
 
+  const rootClassName = useMemo(() => (
+    [
+      'deck-root',
+      `fire-runtime-consumer`,
+      `fire-runtime-consumer--${consumer.id}`,
+      className,
+    ].filter(Boolean).join(' ')
+  ), [className, consumer.id]);
+
   if (error) return <div className="deck-error" role="alert">{error}</div>;
 
   return (
-    <div className="deck-root">
+    <div
+      ref={rootRef}
+      className={rootClassName}
+      data-consumer-id={consumer.id}
+    >
       <canvas
         ref={worldCanvasRef}
         width={Math.max(1, Math.round(dimensions.width * dimensions.pixelRatio))}
@@ -4952,6 +4585,17 @@ f32(284, occlusionStepBudget);
         onChange={loadPresetFromDisk}
       />
 
+      {!consumer.showTopbar && (
+        <div className="fire-runtime-badge deck-panel" aria-label="Consumer runtime summary">
+          <div className="fire-runtime-badge-title">{consumer.label}</div>
+          <div className="fire-runtime-badge-meta">
+            <span>{SCENES.find((scene) => scene.id === selectedSceneId)?.name ?? 'Custom'}</span>
+            <span>{qualityMode === 'accurate' ? 'Accurate' : 'Realtime'}</span>
+          </div>
+        </div>
+      )}
+
+      {consumer.showTopbar && (
       <header className="deck-topbar">
         <div className="deck-topbar-left">
           <Flame size={16} className="deck-brand-icon" />
@@ -5021,7 +4665,9 @@ f32(284, occlusionStepBudget);
           </div>
         </div>
       </header>
+      )}
 
+      {consumer.showControlsPanel && (
       <aside className={`deck-left deck-panel ${controlsVisible ? '' : 'is-hidden'}`} aria-label="Control deck">
         <nav className="deck-left-rail" aria-label="Sections">
           <button type="button" className={`deck-rail-btn ${deckRailSection === 'home' ? 'is-active' : ''}`} aria-label="Tuning" onClick={() => setDeckRailSection('home')}><Flame size={18} /></button>
@@ -5056,7 +4702,9 @@ f32(284, occlusionStepBudget);
           </div>
         </div>
       </aside>
+      )}
 
+      {consumer.showDiagnosticsPanel && (
       <aside className="deck-diagnostics deck-panel" aria-label="Diagnostics">
         <div className="deck-diag-head">
           <span>Diagnostics</span>
@@ -5269,7 +4917,9 @@ f32(284, occlusionStepBudget);
           </div>
         </div>
       </aside>
+      )}
 
+      {consumer.showStatusBar && (
       <footer className="deck-statusbar" aria-label="Status">
         <div className="deck-status-inner">
           <div className="deck-status-item"><Thermometer size={14} /><span>Peak Temp:</span><strong>{tempC} °C</strong></div>
@@ -5279,6 +4929,7 @@ f32(284, occlusionStepBudget);
           <div className="deck-status-item"><Gauge size={14} /><span>Sim Time:</span><strong>{simTimeSeconds.toFixed(1)} s</strong></div>
         </div>
       </footer>
+      )}
 
       {runtimeWarning && (
         <div className="deck-toast deck-panel" role="alert">
@@ -5508,3 +5159,4 @@ const ProfileMeter: React.FC<{
 );
 
 export default FluidSimulation;
+

--- a/components/fireRuntime/consumers.ts
+++ b/components/fireRuntime/consumers.ts
@@ -1,0 +1,115 @@
+import type {
+  CompositionDebugMode,
+  QualityMode,
+} from '../fluid/debugConfig';
+
+export type FireRuntimeConsumerId =
+  | 'control-deck'
+  | 'scene-embed'
+  | 'site-hero'
+  | 'cursor-fx'
+  | 'ambient-background';
+
+export interface FireRuntimeConsumerDefinition {
+  id: FireRuntimeConsumerId;
+  label: string;
+  tagline: string;
+  description: string;
+  useCase: string;
+  initialSceneId: number;
+  initialQualityMode: QualityMode;
+  initialCompositionMode: CompositionDebugMode;
+  initialSmokeEnabled: boolean;
+  initialResolutionScale: number;
+  showTopbar: boolean;
+  showControlsPanel: boolean;
+  showDiagnosticsPanel: boolean;
+  showStatusBar: boolean;
+}
+
+export const FIRE_RUNTIME_CONSUMERS: FireRuntimeConsumerDefinition[] = [
+  {
+    id: 'control-deck',
+    label: 'Control Deck',
+    tagline: 'Full product surface for tuning, diagnostics, and capture.',
+    description: 'The existing operator-facing app with all deck chrome enabled. This is the heavy consumer that exposes presets, telemetry, capture, and debugging controls.',
+    useCase: 'Primary authoring and debugging surface for the runtime.',
+    initialSceneId: 0,
+    initialQualityMode: 'accurate',
+    initialCompositionMode: 'composited',
+    initialSmokeEnabled: true,
+    initialResolutionScale: 0.9,
+    showTopbar: true,
+    showControlsPanel: true,
+    showDiagnosticsPanel: true,
+    showStatusBar: true,
+  },
+  {
+    id: 'scene-embed',
+    label: '3D Scene Embed',
+    tagline: 'Runtime mounted into a cinematic scene shell with minimal chrome.',
+    description: 'A product-facing 3D consumer where the fire is part of a scene, not the whole app. The runtime stays accurate, but control chrome is hidden so it behaves like an embeddable scene widget.',
+    useCase: 'Three.js scenes, configurators, product worlds, and interactive art.',
+    initialSceneId: 4,
+    initialQualityMode: 'accurate',
+    initialCompositionMode: 'composited',
+    initialSmokeEnabled: true,
+    initialResolutionScale: 0.85,
+    showTopbar: false,
+    showControlsPanel: false,
+    showDiagnosticsPanel: false,
+    showStatusBar: false,
+  },
+  {
+    id: 'site-hero',
+    label: '2D Site Hero',
+    tagline: 'Fire as a branded hero treatment behind marketing copy.',
+    description: 'A leaner consumer meant for landing pages and editorial sites. It emphasizes the flame layer and strips the app chrome so the runtime behaves like a motion background component.',
+    useCase: 'Hero sections, editorial headers, and campaign pages.',
+    initialSceneId: 1,
+    initialQualityMode: 'accurate',
+    initialCompositionMode: 'fire_only',
+    initialSmokeEnabled: false,
+    initialResolutionScale: 0.78,
+    showTopbar: false,
+    showControlsPanel: false,
+    showDiagnosticsPanel: false,
+    showStatusBar: false,
+  },
+  {
+    id: 'cursor-fx',
+    label: 'Cursor Effect',
+    tagline: 'A compact, responsive flame treatment for pointer-led interactions.',
+    description: 'A lightweight presentation of the same physics tuned as an effect primitive rather than a scene. It keeps only the fire layer and lower resolution defaults so the runtime can back interactive cursor treatments.',
+    useCase: 'Cursor trails, interactive reveals, and motion accents.',
+    initialSceneId: 3,
+    initialQualityMode: 'realtime',
+    initialCompositionMode: 'fire_only',
+    initialSmokeEnabled: false,
+    initialResolutionScale: 0.68,
+    showTopbar: false,
+    showControlsPanel: false,
+    showDiagnosticsPanel: false,
+    showStatusBar: false,
+  },
+  {
+    id: 'ambient-background',
+    label: 'Ambient Background',
+    tagline: 'Low-UI atmospheric fire for lobbies, installs, and backdrop loops.',
+    description: 'An always-on background consumer focused on stability and lower steady-state cost. It demonstrates the runtime as an environmental motion system, not a direct interaction surface.',
+    useCase: 'Ambient loops, lounge backdrops, installation screens, and idle states.',
+    initialSceneId: 6,
+    initialQualityMode: 'realtime',
+    initialCompositionMode: 'fire_only',
+    initialSmokeEnabled: true,
+    initialResolutionScale: 0.72,
+    showTopbar: false,
+    showControlsPanel: false,
+    showDiagnosticsPanel: false,
+    showStatusBar: false,
+  },
+];
+
+export const FIRE_RUNTIME_CONSUMER_MAP = Object.fromEntries(
+  FIRE_RUNTIME_CONSUMERS.map((consumer) => [consumer.id, consumer])
+) as Record<FireRuntimeConsumerId, FireRuntimeConsumerDefinition>;

--- a/components/fireRuntime/transport.ts
+++ b/components/fireRuntime/transport.ts
@@ -1,0 +1,395 @@
+export class ShaderContract {
+  public layout: GPUPipelineLayout;
+  public bindGroupLayout: GPUBindGroupLayout;
+
+  constructor(device: GPUDevice, label: string, entries: GPUBindGroupLayoutEntry[]) {
+    this.bindGroupLayout = device.createBindGroupLayout({
+      entries,
+      label: `${label}_BGL`
+    });
+
+    this.layout = device.createPipelineLayout({
+      bindGroupLayouts: [this.bindGroupLayout],
+      label: `${label}_PL`
+    });
+  }
+
+  createBindGroup(device: GPUDevice, label: string, entries: GPUBindGroupEntry[]): GPUBindGroup {
+    return device.createBindGroup({
+      layout: this.bindGroupLayout,
+      entries,
+      label: `${label}_BG`
+    });
+  }
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+export class FluidTransport {
+  public uniformBuffer: GPUBuffer;
+
+  private uniformStaging: ArrayBuffer;
+  private uniformView: DataView;
+
+  public densityA: GPUBuffer;
+  public densityB: GPUBuffer;
+  public fuelA: GPUBuffer;
+  public fuelB: GPUBuffer;
+  public sootA: GPUBuffer;
+  public sootB: GPUBuffer;
+  public velocityA: GPUBuffer;
+  public velocityB: GPUBuffer;
+  public velocityScratch: GPUBuffer;
+  public divergence: GPUBuffer;
+  public pressureA: GPUBuffer;
+  public pressureB: GPUBuffer;
+  public occupancy: GPUBuffer;
+  public rayStepCounter: GPUBuffer;
+  public velocityBufferSize: number;
+  public macrocellsPerAxis: number;
+
+  public physicsContract!: ShaderContract;
+  public renderContract!: ShaderContract;
+  public projectionDivContract!: ShaderContract;
+  public projectionJacobiContract!: ShaderContract;
+  public projectionGradContract!: ShaderContract;
+  public occupancyContract!: ShaderContract;
+
+  public physicsGroups: GPUBindGroup[] = [];
+  public renderGroups: GPUBindGroup[] = [];
+  public projectionDivGroups: GPUBindGroup[] = [];
+  public projectionJacobiGroups: GPUBindGroup[] = [];
+  public projectionGradGroups: GPUBindGroup[][] = [[], []];
+  public occupancyGroups: GPUBindGroup[] = [];
+
+  constructor(
+    private device: GPUDevice,
+    public dim: number
+  ) {
+    const voxelCount = dim * dim * dim;
+
+    this.uniformBuffer = device.createBuffer({
+      size: 288,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+    });
+
+    this.uniformStaging = new ArrayBuffer(288);
+    this.uniformView = new DataView(this.uniformStaging);
+
+    const bufferUsage = (window as typeof window & { GPUBufferUsage: typeof GPUBufferUsage }).GPUBufferUsage;
+    const storageUsage = bufferUsage.STORAGE | bufferUsage.COPY_DST | bufferUsage.COPY_SRC;
+
+    this.densityA = device.createBuffer({ size: voxelCount * 4, usage: storageUsage });
+    this.densityB = device.createBuffer({ size: voxelCount * 4, usage: storageUsage });
+    this.fuelA = device.createBuffer({ size: voxelCount * 4, usage: storageUsage });
+    this.fuelB = device.createBuffer({ size: voxelCount * 4, usage: storageUsage });
+    this.sootA = device.createBuffer({ size: voxelCount * 4, usage: storageUsage });
+    this.sootB = device.createBuffer({ size: voxelCount * 4, usage: storageUsage });
+
+    this.velocityBufferSize = voxelCount * 16;
+    this.velocityA = device.createBuffer({ size: this.velocityBufferSize, usage: storageUsage });
+    this.velocityB = device.createBuffer({ size: this.velocityBufferSize, usage: storageUsage });
+    this.velocityScratch = device.createBuffer({ size: this.velocityBufferSize, usage: storageUsage });
+    this.divergence = device.createBuffer({ size: voxelCount * 4, usage: storageUsage });
+    this.pressureA = device.createBuffer({ size: voxelCount * 4, usage: storageUsage });
+    this.pressureB = device.createBuffer({ size: voxelCount * 4, usage: storageUsage });
+
+    const macrocellSize = 8;
+    this.macrocellsPerAxis = Math.ceil(dim / macrocellSize);
+    const macrocellCount = this.macrocellsPerAxis ** 3;
+    this.occupancy = device.createBuffer({ size: macrocellCount * 4, usage: storageUsage });
+    device.queue.writeBuffer(this.occupancy, 0, new Uint32Array(macrocellCount));
+
+    this.rayStepCounter = device.createBuffer({ size: 4, usage: storageUsage });
+
+    const zeroF32 = new Float32Array(voxelCount);
+    const initVec4 = new Float32Array(voxelCount * 4);
+    for (let i = 0; i < voxelCount; i++) {
+      initVec4[i * 4 + 3] = 1.0;
+    }
+
+    device.queue.writeBuffer(this.densityA, 0, zeroF32);
+    device.queue.writeBuffer(this.densityB, 0, zeroF32);
+    device.queue.writeBuffer(this.fuelA, 0, zeroF32);
+    device.queue.writeBuffer(this.fuelB, 0, zeroF32);
+    device.queue.writeBuffer(this.sootA, 0, zeroF32);
+    device.queue.writeBuffer(this.sootB, 0, zeroF32);
+    device.queue.writeBuffer(this.velocityA, 0, initVec4);
+    device.queue.writeBuffer(this.velocityB, 0, initVec4);
+    device.queue.writeBuffer(this.velocityScratch, 0, initVec4);
+    device.queue.writeBuffer(this.divergence, 0, zeroF32);
+    device.queue.writeBuffer(this.pressureA, 0, zeroF32);
+    device.queue.writeBuffer(this.pressureB, 0, zeroF32);
+    this.initContracts();
+    this.initBindGroups();
+  }
+
+  private initContracts() {
+    this.physicsContract = new ShaderContract(this.device, 'Physics', [
+      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
+      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+      { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 4, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+      { binding: 5, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 6, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+      { binding: 7, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 8, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+    ]);
+
+    this.renderContract = new ShaderContract(this.device, 'Render', [
+      { binding: 0, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, buffer: { type: 'uniform' } },
+      { binding: 1, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'read-only-storage' } },
+      { binding: 2, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'read-only-storage' } },
+      { binding: 3, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'read-only-storage' } },
+      { binding: 4, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'read-only-storage' } },
+      { binding: 5, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'read-only-storage' } },
+      { binding: 6, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'storage' } },
+    ]);
+
+    this.occupancyContract = new ShaderContract(this.device, 'Occupancy', [
+      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
+      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 4, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+    ]);
+
+    this.projectionDivContract = new ShaderContract(this.device, 'ProjectionDiv', [
+      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
+      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+    ]);
+
+    this.projectionJacobiContract = new ShaderContract(this.device, 'ProjectionJacobi', [
+      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
+      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+    ]);
+
+    this.projectionGradContract = new ShaderContract(this.device, 'ProjectionGrad', [
+      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
+      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+    ]);
+  }
+
+  private initBindGroups() {
+    this.physicsGroups[0] = this.physicsContract.createBindGroup(this.device, 'Phys0', [
+      { binding: 0, resource: { buffer: this.uniformBuffer } },
+      { binding: 1, resource: { buffer: this.densityA } },
+      { binding: 2, resource: { buffer: this.densityB } },
+      { binding: 3, resource: { buffer: this.velocityA } },
+      { binding: 4, resource: { buffer: this.velocityB } },
+      { binding: 5, resource: { buffer: this.fuelA } },
+      { binding: 6, resource: { buffer: this.fuelB } },
+      { binding: 7, resource: { buffer: this.sootA } },
+      { binding: 8, resource: { buffer: this.sootB } },
+    ]);
+
+    this.renderGroups[0] = this.renderContract.createBindGroup(this.device, 'Render0', [
+      { binding: 0, resource: { buffer: this.uniformBuffer } },
+      { binding: 1, resource: { buffer: this.densityB } },
+      { binding: 2, resource: { buffer: this.velocityB } },
+      { binding: 3, resource: { buffer: this.fuelB } },
+      { binding: 4, resource: { buffer: this.sootB } },
+      { binding: 5, resource: { buffer: this.occupancy } },
+      { binding: 6, resource: { buffer: this.rayStepCounter } },
+    ]);
+
+    this.physicsGroups[1] = this.physicsContract.createBindGroup(this.device, 'Phys1', [
+      { binding: 0, resource: { buffer: this.uniformBuffer } },
+      { binding: 1, resource: { buffer: this.densityB } },
+      { binding: 2, resource: { buffer: this.densityA } },
+      { binding: 3, resource: { buffer: this.velocityB } },
+      { binding: 4, resource: { buffer: this.velocityA } },
+      { binding: 5, resource: { buffer: this.fuelB } },
+      { binding: 6, resource: { buffer: this.fuelA } },
+      { binding: 7, resource: { buffer: this.sootB } },
+      { binding: 8, resource: { buffer: this.sootA } },
+    ]);
+
+    this.renderGroups[1] = this.renderContract.createBindGroup(this.device, 'Render1', [
+      { binding: 0, resource: { buffer: this.uniformBuffer } },
+      { binding: 1, resource: { buffer: this.densityA } },
+      { binding: 2, resource: { buffer: this.velocityA } },
+      { binding: 3, resource: { buffer: this.fuelA } },
+      { binding: 4, resource: { buffer: this.sootA } },
+      { binding: 5, resource: { buffer: this.occupancy } },
+      { binding: 6, resource: { buffer: this.rayStepCounter } },
+    ]);
+
+    this.occupancyGroups[0] = this.occupancyContract.createBindGroup(this.device, 'Occupancy0', [
+      { binding: 0, resource: { buffer: this.uniformBuffer } },
+      { binding: 1, resource: { buffer: this.densityB } },
+      { binding: 2, resource: { buffer: this.fuelB } },
+      { binding: 3, resource: { buffer: this.sootB } },
+      { binding: 4, resource: { buffer: this.occupancy } },
+    ]);
+    this.occupancyGroups[1] = this.occupancyContract.createBindGroup(this.device, 'Occupancy1', [
+      { binding: 0, resource: { buffer: this.uniformBuffer } },
+      { binding: 1, resource: { buffer: this.densityA } },
+      { binding: 2, resource: { buffer: this.fuelA } },
+      { binding: 3, resource: { buffer: this.sootA } },
+      { binding: 4, resource: { buffer: this.occupancy } },
+    ]);
+
+    this.projectionDivGroups[0] = this.projectionDivContract.createBindGroup(this.device, 'ProjectionDiv0', [
+      { binding: 0, resource: { buffer: this.uniformBuffer } },
+      { binding: 1, resource: { buffer: this.velocityB } },
+      { binding: 2, resource: { buffer: this.divergence } },
+    ]);
+
+    this.projectionDivGroups[1] = this.projectionDivContract.createBindGroup(this.device, 'ProjectionDiv1', [
+      { binding: 0, resource: { buffer: this.uniformBuffer } },
+      { binding: 1, resource: { buffer: this.velocityA } },
+      { binding: 2, resource: { buffer: this.divergence } },
+    ]);
+
+    this.projectionJacobiGroups[0] = this.projectionJacobiContract.createBindGroup(this.device, 'ProjectionJacobiA2B', [
+      { binding: 0, resource: { buffer: this.uniformBuffer } },
+      { binding: 1, resource: { buffer: this.divergence } },
+      { binding: 2, resource: { buffer: this.pressureA } },
+      { binding: 3, resource: { buffer: this.pressureB } },
+    ]);
+
+    this.projectionJacobiGroups[1] = this.projectionJacobiContract.createBindGroup(this.device, 'ProjectionJacobiB2A', [
+      { binding: 0, resource: { buffer: this.uniformBuffer } },
+      { binding: 1, resource: { buffer: this.divergence } },
+      { binding: 2, resource: { buffer: this.pressureB } },
+      { binding: 3, resource: { buffer: this.pressureA } },
+    ]);
+
+    this.projectionGradGroups[0][0] = this.projectionGradContract.createBindGroup(this.device, 'ProjectionGrad0PressureA', [
+      { binding: 0, resource: { buffer: this.uniformBuffer } },
+      { binding: 1, resource: { buffer: this.velocityScratch } },
+      { binding: 2, resource: { buffer: this.pressureA } },
+      { binding: 3, resource: { buffer: this.velocityB } },
+    ]);
+
+    this.projectionGradGroups[0][1] = this.projectionGradContract.createBindGroup(this.device, 'ProjectionGrad0PressureB', [
+      { binding: 0, resource: { buffer: this.uniformBuffer } },
+      { binding: 1, resource: { buffer: this.velocityScratch } },
+      { binding: 2, resource: { buffer: this.pressureB } },
+      { binding: 3, resource: { buffer: this.velocityB } },
+    ]);
+
+    this.projectionGradGroups[1][0] = this.projectionGradContract.createBindGroup(this.device, 'ProjectionGrad1PressureA', [
+      { binding: 0, resource: { buffer: this.uniformBuffer } },
+      { binding: 1, resource: { buffer: this.velocityScratch } },
+      { binding: 2, resource: { buffer: this.pressureA } },
+      { binding: 3, resource: { buffer: this.velocityA } },
+    ]);
+
+    this.projectionGradGroups[1][1] = this.projectionGradContract.createBindGroup(this.device, 'ProjectionGrad1PressureB', [
+      { binding: 0, resource: { buffer: this.uniformBuffer } },
+      { binding: 1, resource: { buffer: this.velocityScratch } },
+      { binding: 2, resource: { buffer: this.pressureB } },
+      { binding: 3, resource: { buffer: this.velocityA } },
+    ]);
+  }
+
+  public updateUniforms(
+    now: number,
+    params: Record<string, number>,
+    camera: { pos: number[]; target: number[] },
+    sceneType: number
+  ) {
+    const view = this.uniformView;
+    view.setFloat32(0, now, true);
+    view.setFloat32(4, this.dim, true);
+    view.setFloat32(8, params.vorticity ?? 2, true);
+    view.setFloat32(12, params.dissipation ?? 0.992, true);
+    view.setFloat32(16, params.buoyancy ?? 1.0, true);
+    view.setFloat32(20, params.drag ?? 0.02, true);
+    view.setFloat32(24, params.emission ?? 4.0, true);
+    view.setFloat32(28, params.exposure ?? 1.0, true);
+    view.setFloat32(32, params.gamma ?? 2.2, true);
+    view.setFloat32(36, params.scattering ?? 1.0, true);
+    view.setFloat32(40, params.absorption ?? 1.0, true);
+    view.setFloat32(44, params.smokeWeight ?? 1.0, true);
+    view.setFloat32(48, camera.pos[0] ?? 0.5, true);
+    view.setFloat32(52, camera.pos[1] ?? 0.5, true);
+    view.setFloat32(56, camera.pos[2] ?? 2.0, true);
+    view.setFloat32(60, camera.target[0] ?? 0.5, true);
+    view.setFloat32(64, camera.target[1] ?? 0.5, true);
+    view.setFloat32(68, camera.target[2] ?? 0.5, true);
+    view.setFloat32(72, sceneType, true);
+    view.setFloat32(76, params.plumeTurbulence ?? 0.0, true);
+    view.setFloat32(80, params.smokeDissipation ?? 0.0, true);
+    view.setFloat32(84, params.windX ?? 0.0, true);
+    view.setFloat32(88, params.windZ ?? 0.0, true);
+    view.setFloat32(92, params.turbFreq ?? 0.0, true);
+    view.setFloat32(96, params.turbSpeed ?? 0.0, true);
+    view.setFloat32(100, params.fuelEfficiency ?? 1.0, true);
+    view.setFloat32(104, params.heatDiffusion ?? 0.0, true);
+    view.setFloat32(108, params.stepQuality ?? 1.0, true);
+    view.setFloat32(112, params.T_ignite ?? 0.18, true);
+    view.setFloat32(116, params.T_burn ?? 0.55, true);
+    view.setFloat32(120, params.burnRate ?? 6.5, true);
+    view.setFloat32(124, params.fuelInject ?? 0.95, true);
+    view.setFloat32(128, params.heatYield ?? 3.4, true);
+    view.setFloat32(132, params.sootYieldFlame ?? 0.55, true);
+    view.setFloat32(136, params.sootYieldSmolder ?? 1.1, true);
+    view.setFloat32(140, params.hazeConvertRate ?? 0.0, true);
+    view.setFloat32(144, params.T_hazeStart ?? 0.35, true);
+    view.setFloat32(148, params.T_hazeFull ?? 0.75, true);
+    view.setFloat32(152, params.anisotropyG ?? 0.82, true);
+    view.setFloat32(156, params.smokeThickness ?? 1.0, true);
+    view.setFloat32(160, params.smokeDarkness ?? 0.25, true);
+    view.setFloat32(164, params.flameSharpness ?? 4.0, true);
+    view.setFloat32(168, params.volumeHeight ?? 1.0, true);
+    view.setFloat32(172, params.floorUvScale ?? 1.35, true);
+    view.setFloat32(176, params.floorUvWarp ?? 1.2, true);
+    view.setFloat32(180, params.floorBlendStrength ?? 0.85, true);
+    view.setFloat32(184, params.floorNormalStrength ?? 1.05, true);
+    view.setFloat32(188, params.floorMicroStrength ?? 0.55, true);
+    view.setFloat32(192, params.floorSootDarkening ?? 1.25, true);
+    view.setFloat32(196, params.floorSootRoughness ?? 1.1, true);
+    view.setFloat32(200, params.floorCharStrength ?? 1.2, true);
+    view.setFloat32(204, params.floorContactShadow ?? 1.0, true);
+    view.setFloat32(208, params.floorSpecular ?? 1.1, true);
+    view.setFloat32(212, params.floorFireBounce ?? 1.7, true);
+    view.setFloat32(216, params.floorAmbient ?? 0.55, true);
+    view.setFloat32(220, params.lightingFireIntensity ?? 1.75, true);
+    view.setFloat32(224, params.lightingFireFalloff ?? 1.1, true);
+    view.setFloat32(228, params.lightingFlicker ?? 0.2, true);
+    view.setFloat32(232, params.lightingGlow ?? 1.35, true);
+
+    const occlusionModeMap: Record<string, number> = {
+      analytic_sdf: 0,
+      depth_coupled: 1,
+      none: 2,
+    };
+    const overlayModeMap: Record<string, number> = {
+      final: 0,
+      alpha: 1,
+      occlusion: 2,
+      wood_sdf: 3,
+      combustion: 4,
+    };
+
+    view.setFloat32(236, occlusionModeMap[String(params.fireOcclusionMode ?? 'analytic_sdf')] ?? 0, true);
+    view.setFloat32(240, overlayModeMap[String(params.debugOverlayMode ?? 'final')] ?? 0, true);
+
+    const renderWidth = clamp(Number(params.renderWidth ?? 0), 0, 16384);
+    const renderHeight = clamp(Number(params.renderHeight ?? 0), 0, 16384);
+    view.setFloat32(244, renderWidth, true);
+    view.setFloat32(248, renderHeight, true);
+    view.setFloat32(252, clamp(Number(params.rayStepBudget ?? 0), 0, 4096), true);
+    view.setFloat32(256, clamp(Number(params.occlusionStepBudget ?? 0), 0, 1024), true);
+    view.setFloat32(260, clamp(Number(params.worldViewProjReady ?? 0), 0, 1), true);
+
+    const worldViewProj = Array.isArray(params.worldViewProj) ? params.worldViewProj : [];
+    for (let i = 0; i < 4; i++) {
+      view.setFloat32(264 + i * 4, Number(worldViewProj[i] ?? (i === 0 ? 1 : 0)), true);
+    }
+    for (let i = 0; i < 2; i++) {
+      view.setFloat32(280 + i * 4, Number(params[`worldViewProjRow1_${i}`] ?? (i === 1 ? 1 : 0)), true);
+    }
+
+    this.device.queue.writeBuffer(this.uniformBuffer, 0, this.uniformStaging);
+  }
+}

--- a/index.css
+++ b/index.css
@@ -68,6 +68,302 @@ body {
   height: 100%;
 }
 
+.runtime-gallery-app {
+  display: grid;
+  grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+  gap: 18px;
+  padding: 18px;
+}
+
+.runtime-gallery-sidebar,
+.runtime-gallery-stage {
+  min-height: 0;
+}
+
+.runtime-gallery-sidebar {
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 24px;
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, transparent);
+  background:
+    radial-gradient(140% 120% at 0% 0%, rgba(121, 240, 203, 0.12), transparent 35%),
+    linear-gradient(180deg, rgba(7, 14, 22, 0.96), rgba(5, 8, 13, 0.94));
+  box-shadow: var(--panel-shadow);
+  overflow: auto;
+}
+
+.runtime-gallery-stage {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 14px;
+  min-width: 0;
+}
+
+.runtime-gallery-stage-head {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 6px;
+}
+
+.runtime-gallery-stage-head h2,
+.runtime-gallery-head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 2vw, 2rem);
+  line-height: 1.05;
+}
+
+.runtime-gallery-stage-head p,
+.runtime-gallery-head p,
+.runtime-gallery-details dd,
+.runtime-gallery-tab-tagline {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.runtime-gallery-eyebrow {
+  margin: 0 0 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+}
+
+.runtime-gallery-list {
+  display: grid;
+  gap: 10px;
+}
+
+.runtime-gallery-tab {
+  appearance: none;
+  width: 100%;
+  padding: 14px 15px;
+  text-align: left;
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--panel-border) 78%, transparent);
+  background:
+    linear-gradient(180deg, rgba(20, 31, 43, 0.94), rgba(10, 17, 27, 0.9));
+  color: var(--text-main);
+  cursor: pointer;
+  transition: border-color 140ms ease, transform 140ms ease, background 140ms ease;
+}
+
+.runtime-gallery-tab:hover,
+.runtime-gallery-tab.is-active {
+  border-color: color-mix(in srgb, var(--accent-warm) 42%, var(--accent) 18%);
+  transform: translateY(-1px);
+}
+
+.runtime-gallery-tab.is-active {
+  background:
+    radial-gradient(140% 140% at 0% 0%, rgba(255, 156, 99, 0.14), transparent 36%),
+    linear-gradient(180deg, rgba(22, 34, 48, 0.98), rgba(11, 19, 29, 0.92));
+}
+
+.runtime-gallery-tab-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.runtime-gallery-tab-tagline {
+  display: block;
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.runtime-gallery-details {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+}
+
+.runtime-gallery-details dt {
+  margin-bottom: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
+}
+
+.runtime-gallery-frame {
+  position: relative;
+  height: 100%;
+  min-height: 480px;
+  overflow: hidden;
+  border-radius: 26px;
+  border: 1px solid color-mix(in srgb, var(--accent) 16%, transparent);
+  background:
+    radial-gradient(150% 140% at 100% 0%, rgba(255, 156, 99, 0.16), transparent 34%),
+    linear-gradient(180deg, rgba(6, 11, 18, 0.98), rgba(4, 7, 12, 0.96));
+  box-shadow: 0 32px 90px rgba(0, 0, 0, 0.48);
+}
+
+.runtime-gallery-sim {
+  width: 100%;
+  height: 100%;
+}
+
+.runtime-host {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.runtime-host--scene-embed {
+  display: grid;
+  grid-template-rows: auto 1fr;
+}
+
+.runtime-host-toolbar {
+  display: inline-flex;
+  gap: 10px;
+  align-self: start;
+  justify-self: start;
+  margin: 18px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(8, 12, 18, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.runtime-host-caption,
+.runtime-host-copy,
+.runtime-ambient-card,
+.runtime-cursor-card {
+  background: rgba(8, 12, 18, 0.56);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  backdrop-filter: blur(14px);
+}
+
+.runtime-host-caption {
+  align-self: end;
+  justify-self: start;
+  margin: 18px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  color: var(--text-muted);
+}
+
+.runtime-host--site-hero {
+  display: grid;
+  grid-template-rows: auto 1fr;
+}
+
+.runtime-host-nav {
+  display: flex;
+  justify-content: flex-end;
+  gap: 18px;
+  padding: 18px 22px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.runtime-host-copy {
+  align-self: center;
+  justify-self: start;
+  width: min(520px, calc(100% - 48px));
+  margin-left: 24px;
+  padding: 20px 22px;
+  border-radius: 18px;
+}
+
+.runtime-host-copy h2,
+.runtime-host-copy p {
+  margin: 0;
+}
+
+.runtime-kicker {
+  margin-bottom: 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+}
+
+.runtime-host-copy h2 {
+  margin-bottom: 10px;
+  font-size: clamp(2rem, 3vw, 3.4rem);
+  line-height: 0.95;
+}
+
+.runtime-host-copy p:last-child {
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+
+.runtime-host--cursor-fx {
+  display: flex;
+  align-items: end;
+  gap: 16px;
+  padding: 24px;
+}
+
+.runtime-cursor-card,
+.runtime-ambient-card {
+  padding: 14px 16px;
+  border-radius: 16px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.runtime-host--ambient-background {
+  display: flex;
+  align-items: end;
+  gap: 16px;
+  padding: 24px;
+}
+
+.runtime-ambient-card.is-wide {
+  max-width: 340px;
+  line-height: 1.45;
+}
+
+.fire-runtime-badge {
+  position: absolute;
+  left: 16px;
+  top: 16px;
+  z-index: 7;
+  padding: 11px 13px;
+  pointer-events: none;
+}
+
+.fire-runtime-badge-title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.fire-runtime-badge-meta {
+  display: flex;
+  gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: rgba(245, 248, 255, 0.7);
+}
+
+@media (max-width: 1120px) {
+  .runtime-gallery-app {
+    grid-template-columns: 1fr;
+  }
+
+  .runtime-gallery-sidebar {
+    max-height: 42vh;
+  }
+}
+
 .sim-shell {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary

This is the first extraction pass for issue #6.

The goal here is not to pretend the full app/runtime split is done. The goal is to cut a real seam into the current app so the fire system can already be exercised as a reusable runtime mounted by multiple consumer shells.

This PR does three concrete things:

1. Extracts the GPU transport/buffer contract into `components/fireRuntime/transport.ts` so one of the most app-independent runtime pieces no longer lives inside the control-deck component.
2. Adds a formal consumer registry in `components/fireRuntime/consumers.ts` that describes the target host shapes the runtime needs to support.
3. Refactors `FluidSimulation` so it can mount into different consumer profiles and size itself to its own container instead of assuming it always owns the full browser window.

## Consumer Examples Included

The app now ships with a consumer gallery in `App.tsx` that remounts the same runtime into five host examples:

- `Control Deck`: full tuning/diagnostics product surface
- `3D Scene Embed`: minimal scene-mounted runtime shell
- `2D Site Hero`: branded hero/background treatment
- `Cursor Effect`: lighter fire-only interactive effect shell
- `Ambient Background`: lower-UI ambient/idle consumer

These examples are intentionally run one at a time so we can prove the runtime can serve different products without paying for five simultaneous GPU scenes.

## Implementation Notes

- `FluidSimulation` now accepts a `consumerId` and switches chrome/defaults based on the consumer definition instead of hardcoding the control deck as the only host.
- The simulator now measures its own root container with `ResizeObserver`, which is the key requirement for future embedding in 3D scenes, 2D sections, and effect surfaces.
- The full control deck remains intact as the flagship consumer.
- README project structure/docs were updated so the new runtime seam and consumer examples are discoverable.

## What This PR Does Not Claim

- This is not yet a standalone published runtime package.
- This does not yet extract all simulation/rendering code out of `FluidSimulation.tsx`.
- This does not yet provide adapter packages for React/Three.js/DOM/canvas consumers.

Those remain follow-up work under issue #6. This PR is the first credible step that makes those follow-ups much less speculative.

## Validation

- `npm run typecheck`
- `npm run build`

## Related

- Partially addresses #6
